### PR TITLE
chg: document parser post plugin run

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,5 +3,5 @@ Command-Line Usage
 
 
 .. sphinx_argparse_cli::
-   :module: quilla
-   :func: make_parser
+   :module: quilla._doc
+   :func: _setup_docs_parser

--- a/src/quilla/_doc.py
+++ b/src/quilla/_doc.py
@@ -1,0 +1,28 @@
+'''
+This file is used to generate the parser for the documentation. It initializes a plugin manager,
+and runs the necessary hooks to set up the parser. This is done so that local plugins will also
+appear in the usage documentation from ``doc/usage.rst``.
+'''
+
+import logging
+
+from quilla import (
+    make_parser,
+)
+from quilla.plugins import get_plugin_manager
+
+
+def _setup_docs_parser():
+    '''
+    This function is deliberately not called anywhere, and will not show up
+    in the documentation.
+    '''
+    logger = logging.getLogger(__name__)
+    logger.addHandler(logging.NullHandler())
+
+    parser = make_parser()
+    pm = get_plugin_manager('.', logger)
+
+    pm.hook.quilla_addopts(parser=parser)
+
+    return parser

--- a/src/quilla/_doc.py
+++ b/src/quilla/_doc.py
@@ -1,6 +1,6 @@
 '''
 This file is used to generate the parser for the documentation. It initializes a plugin manager,
-and runs the necessary hooks to set up the parser. This is done so that local plugins will also
+and runs the necessary hooks to set up the parser. This is done so that built-in plugins will also
 appear in the usage documentation from ``doc/usage.rst``.
 '''
 


### PR DESCRIPTION
With the VisualParity validation type, the actual handling of the validation will be done through local plugins internal to Quilla, so this new documentation parser will be able to provide the actual usage docs that will include the new options that the plugins will specify.