### PR TITLE
new: added logic for visualparity validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup(
         'selenium',
         'pluggy',
         'msedge-selenium-tools',
-        'pydeepmerge'
+        'pydeepmerge',
+        'pillow'
     ],
     tests_require=extra_dependencies['tests'],
     extras_require=extra_dependencies,

--- a/src/quilla/common/enums.py
+++ b/src/quilla/common/enums.py
@@ -100,3 +100,13 @@ class OutputSources(Enum):
     LITERAL = 'Literal'
     XPATH_TEXT = 'XPathText'
     XPATH_PROPERTY = 'XPathProperty'
+
+
+class VisualParityImageType(Enum):
+    '''
+    The types of images that are supported by the
+    VisualParity validation state
+    '''
+
+    BASELINE = 'Baseline'
+    TREATMENT = 'Treatment'

--- a/src/quilla/common/utils.py
+++ b/src/quilla/common/utils.py
@@ -81,7 +81,7 @@ class EnumResolver:
         if ctx is not None:
             resolved_plugin_value = ctx.pm.hook.quilla_resolve_enum_from_name(name=name, enum=enum)
 
-            if resolved_plugin_value is not None:
-                return resolved_plugin_value
+            if len(resolved_plugin_value) > 0:
+                return resolved_plugin_value[0]
 
         raise EnumValueNotFoundException(name, enum)


### PR DESCRIPTION
Added the base logic for the VisualParity validation state, which will always fail at this point since there is no storage plugin to manage the baseline and treatment images.

The image comparison is done through the Python Image Library fork called Pillow.

Closes #30 