### PR TITLE
Fixed example "Validation.json" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Check out the [features](docs/features.md) docs for an overview of all quilla ca
           "action": "Validate",
           "type": "URL",
           "state": "Contains",
-          "target": "bing",
+          "target": "bing"
         }
       ]
     }


### PR DESCRIPTION
The example provided in README.md is not a valid "json".